### PR TITLE
Escape " " to make it compatible with Linux / Mac

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,10 +66,10 @@ export function activate(context: vscode.ExtensionContext) {
       const cmdScript = rulesPath
         ? `set echo on
 format rules ${rulesPath}
-format file "${tempFile}" "${tempFile}"
+format file \\\"${tempFile}\\\" \\\"${tempFile}\\\"
 exit`
         : `set echo on
-format file "${tempFile}" "${tempFile}"
+format file \\\"${tempFile}\\\" \\\"${tempFile}\\\"
 exit`;
       const formatScript = join(storagePath, "format.sql");
 


### PR DESCRIPTION
That should fix the https://github.com/mickeypearce/vscode-oracle-format/issues/5 which I also have the same problem :)